### PR TITLE
Add sampling to eval

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,12 +70,12 @@ app:
   LSTMModelTrainRunner: "lstm_model_train_runner.py"
   DependenciesShell: "install_dependencies.sh"
   Requirements: "requirements.txt"
-  TrainOnly: "Yes"
+  TrainOnly: "No"
 
 datapreprocessing:
 
   # Config to data preprocessing parameters
-  sample: "True"
+  sample: "False"
   sample_rate: "0.5"
   num_prods: "4900"
 
@@ -89,13 +89,13 @@ lstmmodel:
   item_embeddings_layer_name: "item_embedding_layer"
   batch_size: 32
   num_epochs: 1
-  steps_per_epoch: 10
+  steps_per_epoch: 2
   save_path: "/home/ubuntu/sequence_models/model_out/lstm_model/"
   save_item_embeddings_path: "/home/ubuntu/sequence_models/model_out/item_embeddings/epoch_{}/"
   save_item_embeddings_period: 1
   early_stopping_patience: 5
   save_period: 1
-  eval_samp_rate: 0.1
+  eval_samp_rate: 0.2
 
 s3:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,13 +70,13 @@ app:
   LSTMModelTrainRunner: "lstm_model_train_runner.py"
   DependenciesShell: "install_dependencies.sh"
   Requirements: "requirements.txt"
-  TrainOnly: "No"
+  TrainOnly: "Yes"
 
 datapreprocessing:
 
   # Config to data preprocessing parameters
   sample: "True"
-  sample_rate: "0.1"
+  sample_rate: "0.5"
   num_prods: "4900"
 
 lstmmodel:
@@ -95,6 +95,7 @@ lstmmodel:
   save_item_embeddings_period: 1
   early_stopping_patience: 5
   save_period: 1
+  eval_samp_rate: 0.1
 
 s3:
 

--- a/config/load_config.py
+++ b/config/load_config.py
@@ -125,6 +125,7 @@ class ConfigLSTMModel(pydantic.BaseModel):
     save_item_embeddings_period: int
     early_stopping_patience: int
     save_period: int
+    eval_samp_rate: float
 
 
 class ConfigAirflow(pydantic.BaseModel):

--- a/dags/data_staging_model_train.py
+++ b/dags/data_staging_model_train.py
@@ -245,6 +245,7 @@ with DAG(**config["model_train_dag"]) as dag:
             "save_item_embeddings_period": config["lstmmodel"]["save_item_embeddings_period"],
             "early_stopping_patience": config["lstmmodel"]["early_stopping_patience"],
             "save_period": config["lstmmodel"]["save_period"],
+            "eval_samp_rate": config["lstmmodel"]["eval_samp_rate"]
         },
         on_failure_callback=notify_email,
         trigger_rule=TriggerRule.ALL_DONE

--- a/runners/lstm_model_train_runner.py
+++ b/runners/lstm_model_train_runner.py
@@ -28,6 +28,7 @@ def task_lstm_model_fit(
     save_item_embeddings_period: int,
     early_stopping_patience: int,
     save_period: int,
+    eval_samp_rate: int,
 ):
 
     # these parameters are read in originally as strings as they are passed to an EMR cluster in another
@@ -99,6 +100,7 @@ def task_lstm_model_fit(
         data_generator,
         validation_data=(cust_list_valid_x, cust_list_valid_y),
         test_data=(cust_list_test_x, cust_list_test_y),
+        eval_samp_rate=eval_samp_rate,
         epochs=num_epochs,
         steps_per_epoch=steps_per_epoch,
         early_stopping_patience=early_stopping_patience,

--- a/src/models/model_utils.py
+++ b/src/models/model_utils.py
@@ -30,6 +30,8 @@ def evaluate(model: Model, test_data: np.array, eval_samp_rate: float):
         temp = list(zip(x, y))
         random.shuffle(temp)
         x, y = zip(*temp)
+        x = list(x)
+        y = list(y)
         samp_num = round(len(x) * eval_samp_rate)
         x = x[0:samp_num]
         y = y[0:samp_num]

--- a/src/models/model_utils.py
+++ b/src/models/model_utils.py
@@ -2,9 +2,10 @@ from utils.logging_framework import log
 from sklearn.metrics import precision_score, recall_score, f1_score
 from tensorflow.keras.models import Model
 import numpy as np
+import random
 
 
-def evaluate(model: Model, test_data: np.array):
+def evaluate(model: Model, test_data: np.array, eval_samp_rate: float):
     """
     Function to generate accuracy, precision, recall and f1 scores from a TensorFlow model
 
@@ -14,18 +15,35 @@ def evaluate(model: Model, test_data: np.array):
       Trained TensorFlow model
     test_data: np.array
       array containing lists of x and y values
+    eval_samp_rate: float
+      sample the evaluation sets - no sampling if set to 0 - necessary due to memory limits
+      for large evaluation data sets
 
     """
 
     log.info("Evaluating model on test data")
-    score = model.evaluate(test_data[0], test_data[1], verbose=0)
+
+    x = test_data[0]
+    y = test_data[1]
+
+    if eval_samp_rate > 0:
+        temp = list(zip(x, y))
+        random.shuffle(temp)
+        x, y = zip(*temp)
+        samp_num = round(len(x) * eval_samp_rate)
+        x = x[0:samp_num]
+        y = y[0:samp_num]
+
+        log.info(f"Sampled evaluation data set to {samp_num} records")
+
+    score = model.evaluate(x, y, verbose=0)
     log.info(f"Test loss: {score[0]} / Test accuracy: {score[1]}")
 
-    validation_preds = model.predict(test_data[0])
+    validation_preds = model.predict(x)
     validation_preds = np.where(validation_preds > 0.5, 1, 0)
 
-    precision = precision_score(test_data[1], validation_preds, average="macro")
-    recall = recall_score(test_data[1], validation_preds, average="macro")
-    f1 = f1_score(test_data[1], validation_preds, average="macro")
+    precision = precision_score(y, validation_preds, average="macro")
+    recall = recall_score(y, validation_preds, average="macro")
+    f1 = f1_score(y, validation_preds, average="macro")
 
     log.info(f"Test precision: {precision} / Test recall: {recall} / Test F1: {f1}")

--- a/src/models/next_bask_pred_model.py
+++ b/src/models/next_bask_pred_model.py
@@ -69,6 +69,7 @@ class NextBasketPredModel(object):
         save_item_embeddings_path=None,
         save_item_embeddings_period=None,
         item_embeddings_layer_name=None,
+        eval_samp_rate=None,
     ):
 
         callbacks = []
@@ -87,7 +88,7 @@ class NextBasketPredModel(object):
                 )
             )
         callbacks.append(
-            _TestSetEvaluation(test_data)
+            _TestSetEvaluation(test_data, eval_samp_rate)
             )
 
         history = self._model.fit(
@@ -146,11 +147,12 @@ def _write_item_embeddings(item_embeddings, path, epoch):
 
 class _TestSetEvaluation(Callback):
     """Run evaluation metrics on training end on test set"""
-    def __init__(self, test_data):
+    def __init__(self, test_data, eval_samp_rate):
         self.test_data = test_data
+        self.eval_samp_rate = eval_samp_rate
 
     def on_train_end(self, logs={}):
-        evaluate(self.model, self.test_data)
+        evaluate(self.model, self.test_data, self.eval_samp_rate)
 
 
 


### PR DESCRIPTION
Add ability to sample the test data set for post model fit evaluation.  This was necessary as the larger test data set was causing our of memory errors on prediction with the small ec2